### PR TITLE
Add NLP Toolkits category with SIL Machine entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ A curated list of resources dedicated to Biblical Natural Language Processing
 > _Contribute your favorite Biblical NLP resource by raising a pull request! Please read the [contribution guidelines](https://github.com/BibleNLP/awesome-bible-nlp/blob/main/contributing.md) before raising a [pull request](https://github.com/BibleNLP/awesome-bible-nlp/pulls)._
 
 ## Machine Translation
-- [BibleNLP Corpus](https://github.com/BibleNLP/bible-parallel-corpus) | [on HuggingFace](https://huggingface.co/datasets/bible-nlp/biblenlp-corpus): Collection of open-licensed sentence-level (verse) aligned bi-text in several languages.
+- [ebible Parallel Data](https://github.com/BibleNLP/ebible): Curated corpus of parallel data derived from versions of the Bible provided by eBible.org. 
+- [Biblical Humanities Corpus](https://github.com/BibleNLP/biblical-humanities-corpus) | [on HuggingFace](https://huggingface.co/datasets/bible-nlp/biblenlp-corpus): Collection of open-licensed sentence-level (verse) aligned bi-text in several languages.
 - [Vachan Data Corpus](https://github.com/Bridgeconn/vachan-data/tree/master/parallel-corpora): Collection of 12 minority language New Testament translations from Northern India as sentence-level (verse) aligned bi-text.
 - [OPUS Bible Corpus (bible-uedin)](https://opus.nlpl.eu/bible-uedin.php): Collection of aligned bi-texts based on the Bible in 102 languages. \[[Paper](https://link.springer.com/article/10.1007/s10579-014-9287-y)\]
 
 ## Tokenizers
 - [utoken](https://github.com/uhermjakob/utoken): Universal tokenizer in Python and CLI interface that is also tested on Biblical text.
 
-
 ## Romanizers
 - [uroman](https://github.com/isi-nlp/uroman): Universal Romanizer that can convert any unicode script to roman (latin) script 
+
+## Toolkits
+- [SIL Machine](https://github.com/sillsdev/machine) | [Python version](https://github.com/sillsdev/machine.py) | [JavaScript Version](https://github.com/sillsdev/machine.js): Toolkit for various NLP operations on Biblical content (especially support for Paratext projects).


### PR DESCRIPTION
This PR adds the new NLP Toolkit which lists toolkits that are specifically geared towards Biblical NLP software that do various operations.

This includes the entry from the SIL Machine library.